### PR TITLE
Sound delay/Save states/Genesis Rendering Fix + Also no longer loads on start, press [Page Up] to choose game and then core to load

### DIFF
--- a/Assets/Plugins/RetroUnity/Scripts/GameManager.cs
+++ b/Assets/Plugins/RetroUnity/Scripts/GameManager.cs
@@ -7,6 +7,8 @@ namespace RetroUnity {
 
         [SerializeField] private string CoreName = "snes9x_libretro.dll";
         [SerializeField] private string RomName = "Chrono Trigger (USA).sfc";
+        private string RAMPath = "";
+        private string STATEPath = "";
         private LibretroWrapper.Wrapper wrapper;
 
         private float _frameTimer;
@@ -27,6 +29,11 @@ namespace RetroUnity {
                     wrapper.Update();
                     _frameTimer -= timePerFrame;
                 }
+
+                if (Input.GetKeyDown(KeyCode.G))
+                    saveState();
+                else if (Input.GetKeyDown(KeyCode.H))
+                    loadState();
             }
             if (LibretroWrapper.tex != null) {
                 Display.material.mainTexture = LibretroWrapper.tex;
@@ -34,6 +41,11 @@ namespace RetroUnity {
         }
 
         public void LoadRom(string path) {
+
+            RAMPath = path.Substring(0, path.LastIndexOf('.'));
+            STATEPath = RAMPath + ".state";
+            RAMPath += ".srm";
+
 #if !UNITY_ANDROID || UNITY_EDITOR
             // Doesn't work on Android because you can't do File.Exists in StreamingAssets folder.
             // Should figure out a different way to perform check later.
@@ -49,9 +61,23 @@ namespace RetroUnity {
 
             wrapper.Init();
             wrapper.LoadGame(path);
+            wrapper.LoadRAM(RAMPath);
+
+        }
+
+        public void saveState()
+        {
+            wrapper.SaveState(STATEPath);
+        }
+
+        public void loadState()
+        {
+            wrapper.LoadState(STATEPath);
         }
 
         private void OnDestroy() {
+            wrapper.SaveRAM(RAMPath);
+            wrapper.DeInit();
             WindowsDLLHandler.Instance.UnloadCore();
         }
     }

--- a/Assets/Plugins/RetroUnity/Scripts/Speaker.cs
+++ b/Assets/Plugins/RetroUnity/Scripts/Speaker.cs
@@ -7,7 +7,18 @@ namespace RetroUnity {
 
         private AudioSource _speaker;
 
-        private void Start() {
+        private bool started = false;
+        //private void Update()
+        //{
+        //    if (!started && LibretroWrapper.Wrapper.AudioBatch.Count != 0)
+        //    {
+        //        startAudio();
+        //    }
+        //}
+
+        public void startAudio()
+        {
+            
             _speaker = GetComponent<AudioSource>();
             if (_speaker == null) return;
             //var audioConfig = AudioSettings.GetConfiguration();
@@ -20,6 +31,7 @@ namespace RetroUnity {
             //_speaker.loop = true;
             //Debug.Log("Unity sample rate: " + audioConfig.sampleRate);
             //Debug.Log("Unity buffer size: " + audioConfig.dspBufferSize);
+            started = true;
         }
 
         private void OnAudioFilterRead(float[] data, int channels) {
@@ -30,7 +42,10 @@ namespace RetroUnity {
             for (i = 0; i < data.Length; i++)
                 data[i] = LibretroWrapper.Wrapper.AudioBatch[i];
             // remove data from the beginning
-            LibretroWrapper.Wrapper.AudioBatch.RemoveRange(0, i);
+            if (LibretroWrapper.Wrapper.AudioBatch.Count < 10000)
+                LibretroWrapper.Wrapper.AudioBatch.RemoveRange(0, i);
+            else
+                LibretroWrapper.Wrapper.AudioBatch.RemoveRange(0, 10000); //clear out excess data, since my method method has no audio lag, but seems to provide trailing numbers
         }
 
         private void OnGUI() {


### PR DESCRIPTION
Fixing sound delay, and adding save files using RAM saving as well as save states, compatible with retroarch's actual files, for cross-loading. 
RAM saves and states are created in the same directory as the rom file is, for convenience, but they don't have to be, the functions take a full path to create the file, so it can be wherever. 